### PR TITLE
Enable optimized x86_64 version when CMAKE_SYSTEM_PROCESSOR is AMD64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ set_property(TARGET argon2 APPEND PROPERTY
     COMPATIBLE_INTERFACE_STRING ARGON2_MAJOR_VERSION
 )
 
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64)$")
     function(add_feature_impl FEATURE GCC_FLAG DEF)
         add_library(argon2-${FEATURE} STATIC
             arch/x86_64/lib/argon2-${FEATURE}.c


### PR DESCRIPTION
E.g. on Windows

Note that to build under Windows (using MSYS2) I also needed to remove `-lrt`.
Changes in the Automake version might also be necessary to use that.